### PR TITLE
Enabling 3d rendering in egui::Image or epaint::Mesh on egui_wgpu_backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,38 @@ impl RenderPass {
     ///  &self.image
     /// }
     /// }
-    ///  let renderer_size=Extent3d{width:1280,height:720,depth:1};
+    /// const SCREEN_WIDTH:u32=640;
+    /// const SCREEN_HEIGHT:u32=480;
+    /// fn main(){
+    ///  let renderer_size=Extent3d{width:SCREEN_WIDTH,height:SCREEN_HEIGHT,depth:1};
     ///  let renderer=Renderer::init(renderer_size,device.clone(),queue.clone());
     ///  egui_pass.texture_as_egui_texture_id(&device,&texture);
+    ///  event_loop.run(move |event,_,control_flow|{
+    ///  match event{
+    /// RedrawRequested(..)=>{
+    /// /*normal egui_wgpu_backend code*/
+    /// /*call render before execute */
+    ///                 egui::Window::new("RotateBox")
+    ///                     .fixed_size(Vec2 {
+    ///                         x: SCREEN_WIDTH as f32,
+    ///                         y: SCREEN_HEIGHT as f32,
+    ///                     })
+    ///                     .show(&platform.context(), |ui| {
+    ///                         ui.image(
+    ///                            texture_id_for_rotate_box_screen,
+    ///                             Vec2 {
+    ///                                 x: SCREEN_WIDTH as f32,
+    ///                                 y: SCREEN_HEIGHT as f32,
+    ///                             },
+    ///                         );
+    ///                     });
+    /// renderer.render();
+    /// egui_pass.execute();
+    /// }
+    ///_=>{*control_flow=ControlFlow::Poll}
+    /// }
+    /// });
+    /// }
     /// ```
     pub fn texture_as_egui_texture_id(
         &mut self,


### PR DESCRIPTION
I inspired from this tweet so i decided to create 3d renderable area without bettween CPU and GPU memory copy.
There are two approach ;

- mark pre allocated texture as egui::TextureId
- replace image that is pointed by TextureId

 
<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve released version 0.2.0 of egui_winit_ash_vk_mem!<a href="https://t.co/PcrrtpGruE">https://t.co/PcrrtpGruE</a><br>User textures are supported from this version.<br>It is now also possible to draw a scene inside a window.<a href="https://twitter.com/hashtag/gamedev?src=hash&amp;ref_src=twsrc%5Etfw">#gamedev</a> <a href="https://twitter.com/hashtag/rustlang?src=hash&amp;ref_src=twsrc%5Etfw">#rustlang</a> <a href="https://t.co/CxvoGYjIcQ">pic.twitter.com/CxvoGYjIcQ</a></p>&mdash; 折登 いつき (@MatchaChoco010) <a href="https://twitter.com/MatchaChoco010/status/1360927831149084673?ref_src=twsrc%5Etfw">February 14, 2021</a></blockquote>

I implemented both approach and both have different use case .
but implementation will be  better .

https://user-images.githubusercontent.com/48007646/108384705-58565300-724e-11eb-9c4f-d91c0f0953c2.mp4


 