### PR TITLE
Set `strip_index_format` to `None`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl RenderPass {
                 cull_mode: wgpu::CullMode::default(),
                 front_face: wgpu::FrontFace::default(),
                 polygon_mode: wgpu::PolygonMode::default(),
-                strip_index_format: Some(wgpu::IndexFormat::Uint32),
+                strip_index_format: None,
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState {
@@ -435,7 +435,7 @@ impl RenderPass {
     ///
     /// This enables the application to reference
     /// the texture inside an image ui element. This effectively enables off-screen rendering inside
-    /// the egui UI. Texture must have the texture format `TextureFormat::Rgba8UnormSrgb` and 
+    /// the egui UI. Texture must have the texture format `TextureFormat::Rgba8UnormSrgb` and
     /// Texture usage `TextureUsage::SAMPLED`.
     pub fn egui_texture_from_wgpu_texture(
         &mut self,


### PR DESCRIPTION
[The wgpu documentation](https://docs.rs/wgpu/0.7.0/wgpu/struct.PrimitiveState.html#structfield.strip_index_format) says that `strip_index_format` 'Should be left `None` for non-strip.', which is the case as we're using `wgpu::PrimitiveTopology::TriangleList`. This fix isn't urgent by any means, but I do get a vulkan validation error because of it:

```
VALIDATION [VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428 (-1077750125)] : Validation Error: [ VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428 ] Object 0: handle = 0x560f78422700, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xbfc2d693 | vkCreateGraphicsPipelines() pCreateInfo[0]: topology is VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST and primitiveRestartEnable is VK_TRUE. It is invalid. The Vulkan spec states: If topology is VK_PRIMITIVE_TOPOLOGY_POINT_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_LIST, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY or VK_PRIMITIVE_TOPOLOGY_PATCH_LIST, primitiveRestartEnable must be VK_FALSE (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428)
```