### PR TITLE
Add sample count to RenderPass

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub struct RenderPass {
 
 impl RenderPass {
     /// Creates a new render pass to render a egui UI.
-    pub fn new(device: &wgpu::Device, output_format: wgpu::TextureFormat) -> Self {
+    pub fn new(device: &wgpu::Device, output_format: wgpu::TextureFormat, msaa_samples: u32) -> Self {
         #[cfg(not(feature = "web"))]
         let vs_module = device.create_shader_module(&include_spirv!("shader/egui.vert.spirv"));
 
@@ -193,7 +193,7 @@ impl RenderPass {
             depth_stencil: None,
             multisample: wgpu::MultisampleState {
                 alpha_to_coverage_enabled: false,
-                count: 1,
+                count: msaa_samples,
                 mask: !0,
             },
 


### PR DESCRIPTION
I'm working on [nannou_egui](https://github.com/AlexEne/nannou_egui) and webgpu currently fails in the validation step because msaa samples are hardcoded in `egui_wgpu_backend` to `1` and [nannou](https://github.com/nannou-org/nannou) sets this to `4`. Right now the solution is to change the msaa in nannou to `1`, but that's not ideal.

I feel like there should be a more correct way to do this that doesn't involve enabling MSAA for the UI code (render UI to a texture then copy the texture in the final buffer), but I am not familiar with webgpu but it is a simple change that seems useful for now.