### PR TITLE
Support both wgpu 0.10 and 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Updated
-- Target wgpu 0.11
+- Target wgpu 0.10 and 0.11
 
 ## [0.12.0] - 2021-08-27
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Updated
+- Target wgpu 0.11
 
 ## [0.12.0] - 2021-08-27
 ### Updated
@@ -13,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0] - 2021-08-19
 ### Updated
-- Target wgou 0.10
+- Target wgpu 0.10
 - Allow replacing wgpu::Texture for a given egui::TextureId.
 - Reduce panics.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ web = []
 
 [dependencies]
 epi = "0.14"
-wgpu = "0.10"
+wgpu = "0.11"
 bytemuck = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ web = []
 
 [dependencies]
 epi = "0.14"
-wgpu = "0.11"
+wgpu = ">=0.10.2, <0.12"
 bytemuck = "1.7"


### PR DESCRIPTION
This PR adjusts the version range for the library's wgpu dependency. Because there were no API changes, both wgpu 0.10 and 0.11 can be supported simultaneously!