### PR TITLE
Srgb Fixes and Renderpass Re-use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- `execute_with_renderpass`, allowing rendering egui onto an existing renderpass.
+
+### Deprecated
+- `web` feature is now a no-op, srgb-ness will be derived from output format.
+
 ### Updated
 
 ## [0.14.0] - 2021-10-27

--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@
 
 Backend code to run [egui](https://github.com/emilk/egui) using [wgpu](https://wgpu.rs/).
 
-## Features
-
- * `web` Using this features will force the backend to output sRGB gamma encoded colors. Normally
-   shaders are supposed to work in linear space, but browsers want sRGBA gamma encoded colors instead.
-
 ## Example
 We have created [a simple example](https://github.com/hasenbanck/egui_example) project to show you, how to use this crate.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@ pub struct RenderPass {
 
 impl RenderPass {
     /// Creates a new render pass to render a egui UI.
+    ///
+    /// If the format passed is not a *Srgb format, the shader will automatically convert to sRGB colors in the shader.
     pub fn new(
         device: &wgpu::Device,
         output_format: wgpu::TextureFormat,
@@ -191,10 +193,10 @@ impl RenderPass {
             label: Some("egui_pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
-                entry_point: if cfg!(feature = "web") {
-                    "vs_web_main"
-                } else {
+                entry_point: if output_format.describe().srgb {
                     "vs_main"
+                } else {
+                    "vs_conv_main"
                 },
                 module: &module,
                 buffers: &[wgpu::VertexBufferLayout {

--- a/src/shader/egui.wgsl
+++ b/src/shader/egui.wgsl
@@ -47,7 +47,7 @@ fn vs_main(
 }
 
 [[stage(vertex)]]
-fn vs_web_main(
+fn vs_conv_main(
     [[location(0)]] a_pos: vec2<f32>,
     [[location(1)]] a_tex_coord: vec2<f32>,
     [[location(2)]] a_color: u32,


### PR DESCRIPTION
Closes #46 
Closes #47 

I have left the `web` feature there, so it wouldn't cause an error on updating, it is just a no-op. However, I can remove it if you wish.

~~Technically this should be able to go out in a patch release.~~ it can't as the removal of the mut can break code if you think of a case hard enough. 