### PR TITLE
egui 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,3 @@ web = []
 epi = "0.16"
 wgpu = "0.12"
 bytemuck = "1.7"
-slab = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 web = []
 
 [dependencies]
-epi = "0.15"
+epi = "0.16"
 wgpu = "0.12"
 bytemuck = "1.7"
+slab = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_wgpu_backend"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
 edition = "2018"
 description = "Backend code to use egui with wgpu."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -770,8 +770,13 @@ impl RenderPass {
         egui::TextureId::User(id)
     }
 
+    /// Frees a user location
+    pub fn free_texture(&mut self, id: u64) {
+        self.user_textures.remove(&id);
+    }
+
     /// Frees a texture id (if that texture was a user texture)
-    pub fn free_texture(&mut self, id: egui::TextureId) {
+    pub fn free_texture_id(&mut self, id: egui::TextureId) {
         if let egui::TextureId::User(id) = id {
             self.user_textures.remove(&id);
         }


### PR DESCRIPTION
Basically copied egui_glium's Painter for the new 0.16 API, as TextureAllocator no longer provides a mutable self.

Right now it doesn't nicely extract `epi::backend::TexAllocationData` from an `epi::Frame` nor does it handle it, which could be something to add.