### PR TITLE
Update to support egui 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Updated
 
+## [0.16.0] - 2021-12-31
+### Updated
+- Target egui 0.16
+
 ## [0.15.0] - 2021-12-18
 ### Added
 - `execute_with_renderpass`, allowing rendering egui onto an existing renderpass.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-epi = "0.16"
+egui = "0.16"
 wgpu = "0.12"
 bytemuck = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_wgpu_backend"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
 edition = "2018"
 description = "Backend code to use egui with wgpu."
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-epi = "0.15"
+epi = "0.16"
 wgpu = "0.12"
 bytemuck = "1.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@ use bytemuck::{Pod, Zeroable};
 pub use wgpu;
 use wgpu::util::DeviceExt;
 
-pub use {epi, epi::egui};
-
 /// Error that the backend can return.
 #[derive(Debug)]
 pub enum BackendError {


### PR DESCRIPTION
Removed the `epi::TextureAllocator` trait impl, since it seems like a relic from the past. I think it wasn't really used in the past anyhow, since the wgpu backend handles resources differently than for example the glow and glium backends.

`egui::Texture` is now called `egui::FontImage`.

Ping @parasyte @cwfitzgerald @Jengamon.

I don't use egui right now, so it would be great if someone could test this change.
