### PR TITLE
Add padding for WebGL support by padding buffer content

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,6 @@ impl RenderPass {
             buffer: uniform_buffer,
             size: std::mem::size_of::<UniformBuffer>(),
         };
-
         let uniform_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("egui_uniform_bind_group_layout"),
@@ -142,7 +141,9 @@ impl RenderPass {
                     visibility: wgpu::ShaderStages::VERTEX,
                     ty: wgpu::BindingType::Buffer {
                         has_dynamic_offset: false,
-                        min_binding_size: None,
+                        min_binding_size: std::num::NonZeroU64::new(
+                            std::mem::size_of::<UniformBuffer>() as u64,
+                        ),
                         ty: wgpu::BufferBindingType::Uniform,
                     },
                     count: None,
@@ -157,7 +158,7 @@ impl RenderPass {
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                     buffer: &uniform_buffer.buffer,
                     offset: 0,
-                    size: None,
+                    size: std::num::NonZeroU64::new(std::mem::size_of::<UniformBuffer>() as u64),
                 }),
             }],
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,9 @@ impl ScreenDescriptor {
 #[repr(C)]
 struct UniformBuffer {
     screen_size: [f32; 2],
+    // Without this padding, rendering would fail for the WebGL backend due to the minimum uniform buffer size of 16 bytes.
+    // See https://github.com/hasenbanck/egui_wgpu_backend/issues/58
+    _padding: [f32; 2],
 }
 
 unsafe impl Pod for UniformBuffer {}
@@ -122,6 +125,7 @@ impl RenderPass {
             label: Some("egui_uniform_buffer"),
             contents: bytemuck::cast_slice(&[UniformBuffer {
                 screen_size: [0.0, 0.0],
+                _padding: [0.0; 2],
             }]),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
@@ -686,6 +690,7 @@ impl RenderPass {
             0,
             bytemuck::cast_slice(&[UniformBuffer {
                 screen_size: [logical_width as f32, logical_height as f32],
+                _padding: [0.0; 2],
             }]),
         );
 


### PR DESCRIPTION
First: thanks for providing the egui backends! With Vulkan everything worked out of the box, but with WASM/WebGL I ran into the issue described here: https://github.com/hasenbanck/egui_wgpu_backend/issues/58

Since at least one other person had the same issue [here](https://github.com/gfx-rs/wgpu/issues/2573), I thought that I might as well push my local fork. In addition to the padding that solves the WebGL issue, I also added size limits in a separate commit.