### PR TITLE
Upgrade to wgpu 0.13 and egui 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_wgpu_backend"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
 edition = "2018"
 description = "Backend code to use egui with wgpu."
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-egui = { version = "0.17", features = [ "convert_bytemuck" ] }
-wgpu = "0.12"
+egui = { version = "0.18", features = ["bytemuck"] }
+wgpu = "0.13"
 bytemuck = "1.7"

--- a/src/shader/egui.wgsl
+++ b/src/shader/egui.wgsl
@@ -1,15 +1,15 @@
 // Vertex shader bindings
 
 struct VertexOutput {
-    [[location(0)]] tex_coord: vec2<f32>;
-    [[location(1)]] color: vec4<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) tex_coord: vec2<f32>;
+    @location(1) color: vec4<f32>;
+    @builtin(position) position: vec4<f32>;
 };
 
 struct Locals {
     screen_size: vec2<f32>;
 };
-[[group(0), binding(0)]] var<uniform> r_locals: Locals;
+@group(0) @binding(0) var<uniform> r_locals: Locals;
 
 fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     let cutoff = srgb < vec3<f32>(10.31475);
@@ -18,11 +18,11 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(
-    [[location(0)]] a_pos: vec2<f32>,
-    [[location(1)]] a_tex_coord: vec2<f32>,
-    [[location(2)]] a_color: u32,
+    @location(0) a_pos: vec2<f32>,
+    @location(1) a_tex_coord: vec2<f32>,
+    @location(2) a_color: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
@@ -46,11 +46,11 @@ fn vs_main(
     return out;
 }
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_conv_main(
-    [[location(0)]] a_pos: vec2<f32>,
-    [[location(1)]] a_tex_coord: vec2<f32>,
-    [[location(2)]] a_color: u32,
+    @location(0) a_pos: vec2<f32>,
+    @location(1) a_tex_coord: vec2<f32>,
+    @location(2) a_color: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coord = a_tex_coord;
@@ -76,10 +76,10 @@ fn vs_conv_main(
 
 // Fragment shader bindings
 
-[[group(1), binding(0)]] var r_tex_color: texture_2d<f32>;
-[[group(1), binding(1)]] var r_tex_sampler: sampler;
+@group(1) @binding(0) var r_tex_color: texture_2d<f32>;
+@group(1) @binding(1) var r_tex_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color * textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
 }

--- a/src/shader/egui.wgsl
+++ b/src/shader/egui.wgsl
@@ -1,13 +1,13 @@
 // Vertex shader bindings
 
 struct VertexOutput {
-    @location(0) tex_coord: vec2<f32>;
-    @location(1) color: vec4<f32>;
-    @builtin(position) position: vec4<f32>;
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) color: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
 struct Locals {
-    screen_size: vec2<f32>;
+    screen_size: vec2<f32>,
 };
 @group(0) @binding(0) var<uniform> r_locals: Locals;
 
@@ -18,7 +18,7 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
-@stage(vertex)
+@vertex
 fn vs_main(
     @location(0) a_pos: vec2<f32>,
     @location(1) a_tex_coord: vec2<f32>,
@@ -46,7 +46,7 @@ fn vs_main(
     return out;
 }
 
-@stage(vertex)
+@vertex
 fn vs_conv_main(
     @location(0) a_pos: vec2<f32>,
     @location(1) a_tex_coord: vec2<f32>,
@@ -79,7 +79,7 @@ fn vs_conv_main(
 @group(1) @binding(0) var r_tex_color: texture_2d<f32>;
 @group(1) @binding(1) var r_tex_sampler: sampler;
 
-@stage(fragment)
+@fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color * textureSample(r_tex_color, r_tex_sampler, in.tex_coord);
 }


### PR DESCRIPTION
This is based on the updated shaders in #55, additionally incorporating fixes for wgpu 0.13 and egui 0.18.

I did not implement the new "custom drawing" feature enabled by the new `ClippedPrimitive` type. I think that'll take a bit of thinking for how it should fit with wgpu.

I've tested this change in a medium-sized game project and it appears to work.

![image](https://user-images.githubusercontent.com/654598/177018679-6d7808d2-509e-4b8b-8886-e84c4f41138c.png)