### PR TITLE
fix: wgsl local uniform padding

### DIFF
--- a/src/shader/egui.wgsl
+++ b/src/shader/egui.wgsl
@@ -8,6 +8,7 @@ struct VertexOutput {
 
 struct Locals {
     screen_size: vec2<f32>,
+    padding: vec2<f32>
 };
 @group(0) @binding(0) var<uniform> r_locals: Locals;
 


### PR DESCRIPTION
Without this padding in shader, I will get a validation error with webgl2 wgpu backend.
```
panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `egui_pipeline`
    Downlevel flags BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED are required but not supported on the device.
This is not an invalid use of WebGPU: the underlying API or device does not support enough features to be a fully compliant implementation. A subset of the features can still be used. If you are running this program on native and not in a browser and wish to work around this issue, call Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current platform supports.

', /Users/currypseudo/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/wgpu-0.13.1/src/backend/direct.rs:2391:5

Stack:

getImports/imports.wbg.__wbg_new_693216e109162396@http://localhost:8000/balloon.js:321:21
console_error_panic_hook::hook::h213191cfc89b51da@http://localhost:8000/balloon_bg.wasm:wasm-function[2370]:0x330971
core::ops::function::Fn::call::hbeae6744a4abcc48@http://localhost:8000/balloon_bg.wasm:wasm-function[7107]:0x3e7b27
std::panicking::rust_panic_with_hook::h1c368a27f9b0afe1@http://localhost:8000/balloon_bg.wasm:wasm-function[3907]:0x3a9708
std::panicking::begin_panic_handler::{{closure}}::h8e1f8b682ca33009@http://localhost:8000/balloon_bg.wasm:wasm-function[4487]:0x3c522e
std::sys_common::backtrace::__rust_end_short_backtrace::h7f7da41799766719@http://localhost:8000/balloon_bg.wasm:wasm-function[6264]:0x3e4c26
rust_begin_unwind@http://localhost:8000/balloon_bg.wasm:wasm-function[5457]:0x3dce05
core::panicking::panic_fmt::hcdb13a4b2416cf82@http://localhost:8000/balloon_bg.wasm:wasm-function[5480]:0x3dd361
core::ops::function::Fn::call::h3f2fe1799f5e9877@http://localhost:8000/balloon_bg.wasm:wasm-function[4223]:0x3b9e53
wgpu::backend::direct::ErrorSinkRaw::handle_error::hcfa6e5ba0b3a45fd@http://localhost:8000/balloon_bg.wasm:wasm-function[2876]:0x3622d1
<wgpu::backend::direct::Context as wgpu::Context>::device_create_render_pipeline::he4cd0d21aa4b82b4@http://localhost:8000/balloon_bg.wasm:wasm-function[535]:0x168c83
wgpu::Device::create_render_pipeline::h8d97465f1cd97a8c@http://localhost:8000/balloon_bg.wasm:wasm-function[5362]:0x3db556
egui_wgpu_backend::RenderPass::new::h5a3973862f1d1337@http://localhost:8000/balloon_bg.wasm:wasm-function[865]:0x20fb09
...
```