### PR TITLE
Fix RenderPass.execute() fn comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ impl RenderPass {
         }
     }
 
-    /// Executes the egui render pass. When `clear_on_draw` is set, the output target will get cleared before writing to it.
+    /// Executes the egui render pass. When `clear_color` is not None, the output target will get cleared with clear_color before writing to it.
     pub fn execute(
         &self,
         encoder: &mut wgpu::CommandEncoder,


### PR DESCRIPTION
4a76a983fd7 upgraded RenderPass.execute() to use clear_color: Option<wgpu::Color> instead of clear_on_draw: bool for the clear color, but didn't update the function comment to reflect that. This change fixes the function comment to match the new behavior.