### PR TITLE
Update to egui 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-egui = { version = "0.20", features = ["bytemuck"] }
+egui = { version = "0.21", features = ["bytemuck"] }
 wgpu = "0.15"
 bytemuck = "1.7"


### PR DESCRIPTION
Does what it says on the tin — the breaking input API changes in egui don't really matter here