### PR TITLE
bumped egui version to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-egui = { version = "0.22", features = ["bytemuck"] }
+egui = { version = "0.23", features = ["bytemuck"] }
 wgpu = "0.17"
 bytemuck = "1.13"


### PR DESCRIPTION
Bumped the egui version to 0.23. No changes to source needed. Works well for me on Windows in the egui demo project. Let me know if there's any more tests you'd like to see! <3