### PR TITLE
Update WGPU to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ web = []
 
 [dependencies]
 egui = { version = "0.23", features = ["bytemuck"] }
-wgpu = "0.17"
+wgpu = "0.18"
 bytemuck = "1.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,11 +283,13 @@ impl RenderPass {
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: load_operation,
-                    store: true,
+                    store: wgpu::StoreOp::Store,
                 },
             })],
             depth_stencil_attachment: None,
             label: Some("egui main render pass"),
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
         rpass.push_debug_group("egui_pass");
 


### PR DESCRIPTION
WGPU 0.18.0 makes some minor API changes, but doesn't change anything (semantically) that is used by this crate (as far as I can tell)