### PR TITLE
bump egui version to 0.26, wgpu version to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-egui = { version = "0.23", features = ["bytemuck"] }
+egui = { version = "0.26", features = ["bytemuck"] }
 wgpu = "0.18"
 bytemuck = "1.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ web = []
 
 [dependencies]
 egui = { version = "0.26", features = ["bytemuck"] }
-wgpu = "0.18"
+wgpu = "0.19"
 bytemuck = "1.13"


### PR DESCRIPTION
egui 0.26 has a bunch of features & improvements we're looking for in our [project](github.com/lockbook/lockbook). An update to wgpu was also required to get my project building because eframe 0.26 depends on a version of web-sys that's incompatible with anything before wgpu 0.19.