### PR TITLE
bump egui to 0.27 and wgpu to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-egui = { version = "0.26", features = ["bytemuck"] }
-wgpu = "0.19"
+egui = { version = "0.27", features = ["bytemuck"] }
+wgpu = "0.20"
 bytemuck = "1.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
 use bytemuck::{Pod, Zeroable};
 use egui::epaint;
 pub use wgpu;
+use wgpu::PipelineCompilationOptions;
 use wgpu::util::DeviceExt;
 
 /// Error that the backend can return.
@@ -210,6 +211,7 @@ impl RenderPass {
                     // 2: uint color
                     attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Uint32],
                 }],
+                compilation_options: PipelineCompilationOptions::default(),
             },
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
@@ -246,6 +248,7 @@ impl RenderPass {
                     }),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
+                compilation_options: PipelineCompilationOptions::default(),
             }),
             multiview: None,
         });


### PR DESCRIPTION
 * bump `egui` to 0.27
 * bump `wgpu` to 0.20

Only required change for `wgpu` was to add `PipelineCompilationOptions`, and followed the advice "most users can be set to Default::default()" from [docs](https://docs.rs/wgpu/0.20.0/wgpu/struct.PipelineCompilationOptions.html).