### PR TITLE
Bump wgpu version to 23.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ web = []
 
 [dependencies]
 egui = { version = "0.29", features = ["bytemuck"] }
-wgpu = "22.0"
+wgpu = "23.0"
 bytemuck = "1.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,11 +197,11 @@ impl RenderPass {
             label: Some("egui_pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
-                entry_point: if output_format.is_srgb() {
+                entry_point:Some( if output_format.is_srgb() {
                     "vs_main"
                 } else {
                     "vs_conv_main"
-                },
+                }),
                 module: &module,
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: 5 * 4,
@@ -231,7 +231,7 @@ impl RenderPass {
 
             fragment: Some(wgpu::FragmentState {
                 module: &module,
-                entry_point: "fs_main",
+                entry_point: Some("fs_main"),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: output_format,
                     blend: Some(wgpu::BlendState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl RenderPass {
             label: Some("egui_pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
-                entry_point:Some( if output_format.is_srgb() {
+                entry_point: Some( if output_format.is_srgb() {
                     "vs_main"
                 } else {
                     "vs_conv_main"


### PR DESCRIPTION
wgpu v 23.0.0 is out. 

`entry_points are now Optional`
https://github.com/gfx-rs/wgpu/releases/tag/v23.0.0