### PR TITLE
Release 0.34 with egui 0.31 and wgpu 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2025-03-29
+
+### Updated
+
+- Target egui 0.31 and wgpu 0.24
+
 ## [0.33.0] - 2024-12-28
 
 ### Updated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_wgpu_backend"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
 edition = "2018"
 description = "Backend code to use egui with wgpu."
@@ -15,6 +15,6 @@ default = []
 web = []
 
 [dependencies]
-egui = { version = "0.30", features = ["bytemuck"] }
-wgpu = "23.0"
+egui = { version = "0.31", features = ["bytemuck"] }
+wgpu = "24.0"
 bytemuck = "1.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ impl RenderPass {
                 depth_or_array_layers: 1,
             };
 
-            let image_data_layout = wgpu::ImageDataLayout {
+            let image_data_layout = wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(4 * image_size.width),
                 rows_per_image: None,
@@ -471,7 +471,7 @@ impl RenderPass {
                     Some(_) => {
                         if let Some(texture) = o.get().0.as_ref() {
                             queue.write_texture(
-                                wgpu::ImageCopyTexture {
+                                wgpu::TexelCopyTextureInfo {
                                     texture,
                                     mip_level: 0,
                                     origin,
@@ -800,7 +800,7 @@ fn create_texture_and_bind_group(
     label_base: &str,
     origin: wgpu::Origin3d,
     image_data: &[u8],
-    image_data_layout: wgpu::ImageDataLayout,
+    image_data_layout: wgpu::TexelCopyBufferLayout,
     image_size: wgpu::Extent3d,
     texture_bind_group_layout: &wgpu::BindGroupLayout,
 ) -> (wgpu::Texture, wgpu::BindGroup) {
@@ -816,7 +816,7 @@ fn create_texture_and_bind_group(
     });
 
     queue.write_texture(
-        wgpu::ImageCopyTexture {
+        wgpu::TexelCopyTextureInfo {
             texture: &texture,
             mip_level: 0,
             origin,


### PR DESCRIPTION
This upgrades egui/wgpu to the latest versions and version bumps to 0.34 to ready a release.

`wgpu::ImageDataLayout` is now deprecated since it was renamed to  `wgpu::TexelCopyBufferLayout`, so that is fixed in these changes.